### PR TITLE
suggested documentation for new ADL is_flags/max/min in doc/limitations.md and doc/reference.md

### DIFF
--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -23,6 +23,32 @@
 
 * If an enum is declared as a flag enum, its zero value will not be reflected.
 
+* Or, for enum types that are deeply nested in classes and/or namespaces, declare a function called `my_adl_info_struct adl_magic_enum_define_range(my_enum_type)` in the same namespace as `my_enum_type`, which magic_enum will find by ADL (because the function is in the same class/namespace as `my_enum_type`), and whose return type is a struct with `static constexpr` data members containing the same parameters as `magic_enum::customize::enum_range<my_enum_type>`
+  ```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  struct my_adl_info_struct {
+    static constexpr bool is_flags = true;
+    // you can also set min and max here (see Enum Range below)
+    // static constexpr int min = ...;
+    // static constexpr int max = ...;
+  };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  my_adl_info_struct adl_magic_enum_define_range(my_enum_type); 
+  }
+  ```
+
+* As a shorthand, if you only want to set `is_flags` and not `min` or `max`, you can also use `magic_enum::customize::adl_info<is_flags_bool>` to avoid having to define `my_adl_info_struct` in your code:
+```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  magic_enum::customize::adl_info<true> adl_magic_enum_define_range(my_enum_type); 
+  }
+  ```
+
 ## Enum Range
 
 * Enum values must be in the range `[MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]`.
@@ -50,6 +76,32 @@
     static constexpr int max = 300;
     // (max - min) must be less than UINT16_MAX.
   };
+  ```
+
+* Or, for enum types that are deeply nested in classes and/or namespaces, declare a function called `my_adl_info_struct adl_magic_enum_define_range(my_enum_type)` in the same namespace as `my_enum_type`, which magic_enum will find by ADL (because the function is in the same class/namespace as `my_enum_type`), and whose return type is a struct with `static constexpr` data members containing the same parameters as `magic_enum::customize::enum_range<my_enum_type>`
+  ```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  struct my_adl_info_struct {
+    static constexpr int min = 100;
+    static constexpr int max = 300;
+    // you can also set is_flags here
+    // static constexpr bool is_flags = true;
+  };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  my_adl_info_struct adl_magic_enum_define_range(my_enum_type); 
+  }
+  ```
+
+* As a shorthand, if you only want to set `min` and `max` and not `is_flags`, you can also use `magic_enum::customize::adl_info<min_int, max_int>` to avoid having to define `my_adl_info_struct` in your code:
+```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  magic_enum::customize::adl_info<100 /*min*/, 300 /*max*/> adl_magic_enum_define_range(my_enum_type); 
+  }
   ```
 
 ## Aliasing

--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -40,7 +40,7 @@
   ```
 
 * As a shorthand, if you only want to set `is_flags` and not `min` or `max`, you can also use `magic_enum::customize::adl_info<is_flags_bool>` to avoid having to define `my_adl_info_struct` in your code:
-```cpp
+  ```cpp
   namespace Deeply::Nested::Namespace {
   enum class my_enum_type { ... };
   // - magic_enum will find this function by ADL
@@ -95,7 +95,7 @@
   ```
 
 * As a shorthand, if you only want to set `min` and `max` and not `is_flags`, you can also use `magic_enum::customize::adl_info<min_int, max_int>` to avoid having to define `my_adl_info_struct` in your code:
-```cpp
+  ```cpp
   namespace Deeply::Nested::Namespace {
   enum class my_enum_type { ... };
   // - magic_enum will find this function by ADL

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -529,7 +529,7 @@ constexpr bool enum_flags_contains(string_view value, BinaryPredicate p) noexcep
   ```
 
 * As a shorthand, if you only want to set `is_flags` and not `min` or `max`, you can also use `magic_enum::customize::adl_info<is_flags_bool>` to avoid having to define `my_adl_info_struct` in your code:
-```cpp
+  ```cpp
   namespace Deeply::Nested::Namespace {
   enum class my_enum_type { ... };
   // - magic_enum will find this function by ADL

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -512,6 +512,29 @@ constexpr bool enum_flags_contains(string_view value, BinaryPredicate p) noexcep
   magic_enum::enum_flags_test_any(Left|Down|Right, Down|Right); // -> "true"
   ```
 
+* Or, for enum types that are deeply nested in classes and/or namespaces, declare a function called `my_adl_info_struct adl_magic_enum_define_range(my_enum_type)` in the same namespace as `my_enum_type`, which magic_enum will find by ADL lookup, and whose return type is a struct with static data members containing the same parameters as `magic_enum::customize::enum_range<my_enum_type>`
+  ```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  struct my_adl_info_struct {
+    static constexpr bool is_flags = true;
+  };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  my_adl_info_struct adl_magic_enum_define_range(my_enum_type); 
+  }
+  ```
+
+* As a shorthand, if you only want to set `is_flags` and not `min` or `max`, you can also use `magic_enum::customize::adl_info<is_flags_bool>` to avoid having to define `my_adl_info_struct` in your code:
+```cpp
+  namespace Deeply::Nested::Namespace {
+  enum class my_enum_type { ... };
+  // - magic_enum will find this function by ADL
+  // - no need to ever define this function
+  magic_enum::customize::adl_info<true> adl_magic_enum_define_range(my_enum_type); 
+  }
+  ```
+
 ## `is_unscoped_enum`
 
 ```cpp

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -512,12 +512,15 @@ constexpr bool enum_flags_contains(string_view value, BinaryPredicate p) noexcep
   magic_enum::enum_flags_test_any(Left|Down|Right, Down|Right); // -> "true"
   ```
 
-* Or, for enum types that are deeply nested in classes and/or namespaces, declare a function called `my_adl_info_struct adl_magic_enum_define_range(my_enum_type)` in the same namespace as `my_enum_type`, which magic_enum will find by ADL lookup, and whose return type is a struct with static data members containing the same parameters as `magic_enum::customize::enum_range<my_enum_type>`
+* Or, for enum types that are deeply nested in classes and/or namespaces, declare a function called `my_adl_info_struct adl_magic_enum_define_range(my_enum_type)` in the same namespace as `my_enum_type`, which magic_enum will find by ADL (because the function is in the same class/namespace as `my_enum_type`), and whose return type is a struct with `static constexpr` data members containing the same parameters as `magic_enum::customize::enum_range<my_enum_type>`
   ```cpp
   namespace Deeply::Nested::Namespace {
   enum class my_enum_type { ... };
   struct my_adl_info_struct {
     static constexpr bool is_flags = true;
+    // you can also set min and max here (see Limitations document)
+    // static constexpr int min = ...;
+    // static constexpr int max = ...;
   };
   // - magic_enum will find this function by ADL
   // - no need to ever define this function

--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -193,7 +193,7 @@ struct adl_info<Min, Max> {
 
 template<bool IsFlags>
 struct adl_info<IsFlags> {
-    static constexpr int is_flags = IsFlags;
+    static constexpr bool is_flags = IsFlags;
 };
 
 // Enum value must be in range [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]. By default MAGIC_ENUM_RANGE_MIN = -128, MAGIC_ENUM_RANGE_MAX = 127.

--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -163,15 +163,57 @@ static_assert([] {
   return true;
 } (), "magic_enum::customize wchar_t is not compatible with ASCII.");
 
+namespace details {
+    template<typename E, typename = void>
+    constexpr inline bool has_is_flags_adl = false;
+
+    template<typename E>
+    constexpr inline bool has_is_flags_adl < E, std::void_t<decltype(decltype(adl_magic_enum_define_range(E{}))::is_flags) > > = decltype(adl_magic_enum_define_range(E{}))::is_flags;
+
+    template<typename E, typename = void>
+    constexpr inline auto has_minmax_adl = std::pair<int, int>(MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX);
+
+    template<typename E>
+    constexpr inline auto has_minmax_adl < E, std::void_t<decltype(decltype(adl_magic_enum_define_range(E{}))::max), decltype(decltype(adl_magic_enum_define_range(E{}))::max) >> =
+        std::pair<int, int>(decltype(adl_magic_enum_define_range(E{}))::min, decltype(adl_magic_enum_define_range(E{}))::max);
+}
+
+
+
 namespace customize {
+
+template<auto... Vs>
+struct adl_info { static_assert(sizeof...(Vs) && !sizeof...(Vs), "adl_info parameter types must be either 2 ints exactly or 1 bool for the is_flgas"); };
+
+template<int Min, int Max>
+struct adl_info<Min, Max> {
+    static constexpr int min = Min;
+    static constexpr int max = Max;
+};
+
+template<bool IsFlags>
+struct adl_info<IsFlags> {
+    static constexpr int is_flags = IsFlags;
+};
 
 // Enum value must be in range [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]. By default MAGIC_ENUM_RANGE_MIN = -128, MAGIC_ENUM_RANGE_MAX = 127.
 // If need another range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN and MAGIC_ENUM_RANGE_MAX.
 // If need another range for specific enum type, add specialization enum_range for necessary enum type.
-template <typename E>
+template <typename E, typename = void>
 struct enum_range {
-  static constexpr int min = MAGIC_ENUM_RANGE_MIN;
-  static constexpr int max = MAGIC_ENUM_RANGE_MAX;
+    static constexpr int min = MAGIC_ENUM_RANGE_MIN;
+    static constexpr int max = MAGIC_ENUM_RANGE_MAX;
+};
+
+template <typename E>
+struct enum_range < E, decltype(void(adl_magic_enum_define_range(E{}))) > {
+    static constexpr int min = details::has_minmax_adl<E>.first;
+    static constexpr int max = details::has_minmax_adl<E>.second;
+    static constexpr bool is_flags = details::has_is_flags_adl<E>;
+
+    static_assert(is_flags || min != MAGIC_ENUM_RANGE_MIN || max != MAGIC_ENUM_RANGE_MAX, 
+        "adl_magic_enum_define_range is declared for this enum but does not define any constants.\n"
+        "be sure that the member names are static and are not mispelled.");
 };
 
 static_assert(MAGIC_ENUM_RANGE_MAX > MAGIC_ENUM_RANGE_MIN, "MAGIC_ENUM_RANGE_MAX must be greater than MAGIC_ENUM_RANGE_MIN.");

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -49,17 +49,17 @@ struct magic_enum::customize::enum_range<Color> {
   static constexpr bool is_flags = true;
 };
 
-enum class Numbers : int {
-  none = 0,
-  one = 1 << 1,
-  two = 1 << 2,
-  three = 1 << 3,
-  many = 1 << 30,
-};
-template <>
-struct magic_enum::customize::enum_range<Numbers> {
-  static constexpr bool is_flags = true;
-};
+namespace Namespace {
+    enum class Numbers : int {
+        none = 0,
+        one = 1 << 1,
+        two = 1 << 2,
+        three = 1 << 3,
+        many = 1 << 30,
+    };
+    magic_enum::customize::adl_info<true> adl_magic_enum_define_range(Numbers);
+}
+using Namespace::Numbers;
 
 enum Directions : std::uint64_t {
   NoDirection = 0,


### PR DESCRIPTION
Here is some suggested documentation for the new ADL is_flags/max/min feature created by ZXShady (patch-1 in my repository lsemprini/magic-enum, which is a fork of ZXShady/magic-enum)

I only changed doc/limitations.md and doc/reference.md

I have no idea what I'm doing with GitHub, so apologies if I'm using the wrong features to do the suggestion.  I can submit the files another way if you like.
